### PR TITLE
substrate: Use latest transaction version when signing extrinsic

### DIFF
--- a/chains/substrate/connection.go
+++ b/chains/substrate/connection.go
@@ -123,7 +123,7 @@ func (c *Connection) SubmitTx(method utils.Method, args ...interface{}) error {
 		Nonce:              types.NewUCompactFromUInt(uint64(c.nonce)),
 		SpecVersion:        rv.SpecVersion,
 		Tip:                types.NewUCompactFromUInt(0),
-		TransactionVersion: 1,
+		TransactionVersion: rv.TransactionVersion,
 	}
 
 	err = ext.Sign(*c.key, o)


### PR DESCRIPTION
The current version has the `TransactionVersion` set to `1`, with the changes in this PR, we will always use the latest version returned from storage.