### PR TITLE
Update docker image and substrate event field handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 ChainSafe Systems
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM  golang:1.18-stretch AS builder
+FROM  golang:1.22 AS builder
 ADD . /src
 WORKDIR /src
 RUN go mod download


### PR DESCRIPTION
Fields in gsrpc are not represented as a `map[string]any` in the latest version. This PR updates the field retrieval logic to use the `registry.DecodedFields` and adds an override for `types.U256`.