### PR TITLE
substrate: Update the lookup index for u256 field override

### DIFF
--- a/chains/substrate/chain.go
+++ b/chains/substrate/chain.go
@@ -62,6 +62,8 @@ func checkBlockstore(bs *blockstore.Blockstore, startBlock uint64) (uint64, erro
 	}
 }
 
+const U256LookupIndex = 89
+
 func InitializeChain(cfg *core.ChainConfig, logger log15.Logger, sysErr chan<- error, m *metrics.ChainMetrics) (*Chain, error) {
 	kp, err := keystore.KeypairFromAddress(cfg.From, keystore.SubChain, cfg.KeystorePath, cfg.Insecure)
 	if err != nil {
@@ -108,7 +110,7 @@ func InitializeChain(cfg *core.ChainConfig, logger log15.Logger, sysErr chan<- e
 
 	// u256 is represented as [u64;4]. We use this override to skip extra processing when decoding fields with this type.
 	u256FieldOverride := registry.FieldOverride{
-		FieldLookupIndex: 142,
+		FieldLookupIndex: U256LookupIndex,
 		FieldDecoder:     &registry.ValueDecoder[types.U256]{},
 	}
 


### PR DESCRIPTION
Lookup index for U256 field changed from 142 to 89. 

This is a temporary solution until we address this in GSRPC where we should allow field overrides by field names not just lookup indexes.